### PR TITLE
MacOS Homebrew support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,12 @@ endif
 #
 ifeq ($(BUILD_OS),Darwin)
 CFLAGS+=-DDIRENT_HAS_TYPE
+
+ifeq ($(LIB_DIR),)
+LIB+=-L/usr/local/lib
+else
+LIB+=-L$(LIB_DIR)
+endif
 endif
 
 


### PR DESCRIPTION
Allow passing LIB_DIR on Darwin to allow creation of dupd Homebrew tap.